### PR TITLE
Fixes and tweaks to www-misc/zoneminder/files/README.gentoo

### DIFF
--- a/www-misc/zoneminder/files/README.gentoo
+++ b/www-misc/zoneminder/files/README.gentoo
@@ -11,7 +11,8 @@
 2. Set your database settings in /etc/zm/zm.conf, including above zmpass
 
 3. Configure apache to use zoneminder, see /usr/share/doc/zoneminder*/10_zoneminder.conf
-   for an example configuration snippet.
+   for an example configuration snippet. Extract with:
+     bzip2 -d /usr/share/doc/zoneminder*/10_zoneminder.conf.bz2
 
 4. Enable PHP in your webserver configuration,
    APACHE2_OPTS="-D DEFAULT_VHOST -D INFO -D SSL -D SSL_DEFAULT_VHOST -D LANGUAGE -D PHP -D PROXY"

--- a/www-misc/zoneminder/files/README.gentoo
+++ b/www-misc/zoneminder/files/README.gentoo
@@ -2,7 +2,7 @@
    database for zoneminder to use
    (see https://wiki.gentoo.org/wiki/MySQL/Startup_Guide).
    E.g., when logged into mysql as root,
-     mysql> CREATE DATABASE \`zm\`;
+     mysql> CREATE DATABASE zm;
      mysql> grant lock tables,alter,drop,select,insert,update,delete,create,index,alter routine,create routine, trigger,execute on zm.* to 'zmuser'@localhost identified by 'zmpass';
      mysql> flush privileges;
    Once you completed that you should execute the following:

--- a/www-misc/zoneminder/files/README.gentoo
+++ b/www-misc/zoneminder/files/README.gentoo
@@ -1,29 +1,30 @@
-1. If this is a new installation, you will need to create a MySQL
-   database for zoneminder to use
-   (see https://wiki.gentoo.org/wiki/MySQL/Startup_Guide).
-   E.g., when logged into mysql as root,
-     mysql> CREATE DATABASE zm;
-     mysql> grant lock tables,alter,drop,select,insert,update,delete,create,index,alter routine,create routine, trigger,execute on zm.* to 'zmuser'@localhost identified by 'zmpass';
-     mysql> flush privileges;
-   Once you completed that you should execute the following:
-     mysql -p < /usr/share/zoneminder/db/zm_create.sql
+New Installation:
+    1. If this is a new installation, you will need to create a MySQL
+       database for zoneminder to use
+       (see https://wiki.gentoo.org/wiki/MySQL/Startup_Guide).
+       E.g., when logged into mysql as root,
+         mysql> CREATE DATABASE zm;
+         mysql> grant lock tables,alter,drop,select,insert,update,delete,create,index,alter routine,create routine, trigger,execute on zm.* to 'zmuser'@localhost identified by 'zmpass';
+         mysql> flush privileges;
+       Once you completed that you should execute the following:
+         mysql -p < /usr/share/zoneminder/db/zm_create.sql
 
-2. Set your database settings in /etc/zm/zm.conf, including above zmpass
+    2. Set your database settings in /etc/zm/zm.conf, including above zmpass
 
-3. Configure apache to use zoneminder, see /usr/share/doc/zoneminder*/10_zoneminder.conf
-   for an example configuration snippet. Extract with:
-     bzip2 -d /usr/share/doc/zoneminder*/10_zoneminder.conf.bz2
+    3. Configure apache to use zoneminder, see /usr/share/doc/zoneminder*/10_zoneminder.conf
+       for an example configuration snippet. Extract with:
+         bzip2 -d /usr/share/doc/zoneminder*/10_zoneminder.conf.bz2
 
-4. Enable PHP in your webserver configuration,
-   APACHE2_OPTS="-D DEFAULT_VHOST -D INFO -D SSL -D SSL_DEFAULT_VHOST -D LANGUAGE -D PHP -D PROXY"
+    4. Enable PHP in your webserver configuration,
+       APACHE2_OPTS="-D DEFAULT_VHOST -D INFO -D SSL -D SSL_DEFAULT_VHOST -D LANGUAGE -D PHP -D PROXY"
 
-5. set date.timezone in /etc/php/apache2-php*/php.ini
-   and restart/reload the webserver.
+    5. set date.timezone in /etc/php/apache2-php*/php.ini
+       and restart/reload the webserver.
 
-6. Start the zoneminder daemon:
-   /etc/init.d/zoneminder start
+    6. Start the zoneminder daemon:
+       /etc/init.d/zoneminder start
 
-7. Finally point your browser to http://your.webserver/zm
+    7. Finally point your browser to http://your.webserver/zm
 
 
 Upgrading:

--- a/www-misc/zoneminder/files/README.gentoo
+++ b/www-misc/zoneminder/files/README.gentoo
@@ -12,8 +12,8 @@ New Installation:
     2. Set your database settings in /etc/zm/zm.conf, including above zmpass
 
     3. Configure apache to use zoneminder, see /usr/share/doc/zoneminder*/10_zoneminder.conf
-       for an example configuration snippet. Extract with:
-         bzip2 -d /usr/share/doc/zoneminder*/10_zoneminder.conf.bz2
+       for an example configuration snippet.
+         bzcat /usr/share/doc/zoneminder*/10_zoneminder.conf.bz2
 
     4. Enable PHP in your webserver configuration,
        APACHE2_OPTS="-D DEFAULT_VHOST -D INFO -D SSL -D SSL_DEFAULT_VHOST -D LANGUAGE -D PHP -D PROXY"


### PR DESCRIPTION
Notes about changes:
* Both "CREATE DATABASE \\\`zm\\\`;" and "CREATE DATABASE \\\'zm\\\';" are not valid commands. Did not try "CREATE DATABASE 'zm';", but "CREATE DATABASE zm;" works
* "10_zoneminder.conf" is "10_zoneminder.conf.bz2" on new install
* Layout change to distinguish between new & existing installs